### PR TITLE
Wavelet Denoise

### DIFF
--- a/logic/power_bands.py
+++ b/logic/power_bands.py
@@ -3,7 +3,7 @@ from constants import BAND_POWERS
 import utils
 
 from brainflow.board_shim import BoardShim
-from brainflow.data_filter import DataFilter, DetrendOperations, NoiseTypes, WaveletDenoisingTypes, WaveletTypes
+from brainflow.data_filter import DataFilter, DetrendOperations, NoiseTypes, WaveletTypes
 
 import re
 import numpy as np

--- a/logic/power_bands.py
+++ b/logic/power_bands.py
@@ -3,7 +3,7 @@ from constants import BAND_POWERS
 import utils
 
 from brainflow.board_shim import BoardShim
-from brainflow.data_filter import DataFilter, DetrendOperations, NoiseTypes
+from brainflow.data_filter import DataFilter, DetrendOperations, NoiseTypes, WaveletDenoisingTypes, WaveletTypes
 
 import re
 import numpy as np
@@ -42,6 +42,7 @@ class PwrBands(BaseLogic):
         for eeg_chan in self.eeg_channels:
             DataFilter.remove_environmental_noise(data[eeg_chan], self.sampling_rate, NoiseTypes.FIFTY_AND_SIXTY.value)
             DataFilter.detrend(data[eeg_chan], DetrendOperations.LINEAR)
+            DataFilter.perform_wavelet_denoising(data[eeg_chan], WaveletTypes.DB4, 5)
         
         # calculate band features for left, right, and overall
         left_powers, _ = DataFilter.get_avg_band_powers(data, self.left_chans, self.sampling_rate, True)


### PR DESCRIPTION
Big Single Line Change for powerbands and neurofeedback. c:

Explanation: 
>Wavelet denoising stands out from traditional denoising methods due to its multi-resolution analysis, allowing it to effectively handle signals with complex features across different scales. Unlike conventional techniques that may apply uniform filtering, wavelet denoising adapts to the signal's characteristics, providing both time and frequency localization. This adaptability ensures that important signal details are preserved while efficiently removing a wide variety of noise types. Moreover, wavelet denoising is particularly good at maintaining sharp features and edges in the signal, making it a versatile and powerful tool for applications requiring high fidelity signal processing.