### PR TITLE
Fix UnboundLocalError on failed init

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from logic.power_bands import PwrBands
 from logic.neuro_feedback import NeuroFB
 from logic.biometrics import Biometrics
 from logic.addons import Addons
-from logic.ml_action import MLAction
 
 from reporters.osc_reporter import OSC_Reporter
 from reporters.debug_osc_reporter import Debug_Reporter
@@ -140,6 +139,7 @@ def BoardInit(args: argparse.Namespace) -> tuple[BoardShim, list, int]:
     
     ### Add ml action to logics if enabled
     if args.enable_action:
+        from logic.ml_action import MLAction # only import if activated
         logics.append(MLAction(board, ema_decay = ema_decay * args.action_ema_multiplier))
 
     BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Intializing (wait {}s)'.format(startup_time))

--- a/main.py
+++ b/main.py
@@ -22,8 +22,9 @@ def enable_loggers():
     DataFilter.enable_data_logger()
 
 def parse_args() -> argparse.Namespace:
-### Paramater Setting ###
+    ### Paramater Setting ###
     parser = argparse.ArgumentParser()
+
     # use docs to check which parameters are required for specific board, e.g. for Cyton - set serial port
     parser.add_argument('--timeout', type=int, help='timeout for device discovery or connection', required=False,
                         default=0)
@@ -174,8 +175,9 @@ def main():
     
     ### Reporter Setup ###
     reporter = setup_reporter(args)
+    #endregion Configure
 
-    #region init
+    #region Init
     max_retries = args.retry_count
     while True:
         try:
@@ -192,8 +194,9 @@ def main():
             else:
                 BoardShim.log_message(LogLevels.LEVEL_ERROR.value, f'Biosensor board error: {board_init_error}')
                 return
+    #endregion init
 
-    #region main loop
+    #region Main loop
     try:
         while True:
             # get execution start time for time delay
@@ -228,6 +231,7 @@ def main():
     finally:
         reporter.send({Info.__name__ : {Info.CONNECTED:False}})
         board.release_session()
+    #endregion Main loop
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -220,15 +220,12 @@ def main():
             time.sleep(sleep_time)
             
     except TimeoutError as e:
-        # display disconnect and release old session
-        reporter.send({Info.__name__ : {Info.CONNECTED:False}})
-        board.release_session()
-
         BoardShim.log_message(LogLevels.LEVEL_INFO.value, f'Biosensor board error: {e}')
     except KeyboardInterrupt:
         BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Received interrupt signal! Shutting down...')
         board.stop_stream()
     finally:
+        # display disconnect and release old session
         reporter.send({Info.__name__ : {Info.CONNECTED:False}})
         board.release_session()
     #endregion Main loop

--- a/main.py
+++ b/main.py
@@ -17,11 +17,12 @@ from reporters.debug_osc_reporter import Debug_Reporter
 from reporters.deprecated_osc_reporter import Old_OSC_Reporter
 from reporters.reporter import Reporter
 
-def main():
+def enable_loggers():
     BoardShim.enable_board_logger()
     DataFilter.enable_data_logger()
 
-    ### Paramater Setting ###
+def parse_args() -> argparse.Namespace:
+### Paramater Setting ###
     parser = argparse.ArgumentParser()
     # use docs to check which parameters are required for specific board, e.g. for Cyton - set serial port
     parser.add_argument('--timeout', type=int, help='timeout for device discovery or connection', required=False,
@@ -79,8 +80,9 @@ def main():
     parser.add_argument("--action-ema-multiplier", type=float, required=False, default=5.0,
                         help='multiplier to speed up or slow down the reactiveness of ml action logic')
     
-    args = parser.parse_args()
+    return parser.parse_args()
 
+def configure_brainflow_params(args: argparse.Namespace) -> BrainFlowInputParams:
     params = BrainFlowInputParams()
     params.ip_port = args.ip_port
     params.serial_port = args.serial_port
@@ -92,82 +94,108 @@ def main():
     params.timeout = args.timeout
     params.file = args.file
 
-    ### Debug message toggle ###
-    if args.debug:
-        BoardShim.set_log_level(LogLevels.LEVEL_DEBUG.value)
+    return params
 
+def BoardInit(args: argparse.Namespace) -> tuple[BoardShim, list, int]:
     ### Board Id selection ###
     try:
         master_board_id = int(args.board_id)
     except ValueError:
         master_board_id = BoardIds[args.board_id.upper()]
+
+    ### Streaming Params ###
+    refresh_rate_hz = args.refresh_rate
+    window_seconds = args.window_seconds
+    ema_decay = args.ema_decay / args.refresh_rate
+    startup_time = window_seconds
+
+    ### Parse params ###
+    params = configure_brainflow_params(args)
+
+
+    ### Biosensor board setup ###
+    board = BoardShim(master_board_id, params)
+    board.prepare_session()
+
+    ### Logic Modules ###
+    has_muse_ppg = master_board_id in (BoardIds.MUSE_2_BOARD, BoardIds.MUSE_S_BOARD)
     
-    ### Reporter Setup ###
+    fft_size= 64 * 10 # TODO: Make this configurable
+    biometrics_logic = Biometrics(board, has_muse_ppg, fft_size=fft_size, ema_decay=ema_decay)
+
+    logics = [
+        Info(board, window_seconds=window_seconds),
+        PwrBands(board, window_seconds=window_seconds, ema_decay=ema_decay),
+        NeuroFB(board, window_seconds=window_seconds, ema_decay=ema_decay),
+        Addons(board, window_seconds=window_seconds, ema_decay=ema_decay),
+        biometrics_logic
+    ]
+
+    ### Muse 2/S heartbeat support ###
+    if has_muse_ppg:
+        board.config_board('p52')
+        heart_window_seconds = biometrics_logic.window_seconds
+        startup_time = max(startup_time, heart_window_seconds)
+    
+    ### Add ml action to logics if enabled
+    if args.enable_action:
+        logics.append(MLAction(board, ema_decay = ema_decay * args.action_ema_multiplier))
+
+    BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Intializing (wait {}s)'.format(startup_time))
+    board.start_stream(streamer_params=args.streamer_params)
+    time.sleep(startup_time)
+    BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Tracking Started')
+
+    return board, logics, refresh_rate_hz
+
+def setup_reporter(args: argparse.Namespace) -> Reporter:
     ip = args.osc_ip_address
     send_port = args.osc_port
     use_old_reporter = args.use_old_reporter
     reporters = [Old_OSC_Reporter(ip, send_port) if use_old_reporter else OSC_Reporter(ip, send_port)]
+    
     if args.debug:
         reporters.append(Debug_Reporter(ip, send_port))
+
     reporter_dict = {type(rp).__name__:rp for rp in reporters}
-    reporter = Reporter(reporter_dict)
+
+    return Reporter(reporter_dict)
+
+def main():
+    enable_loggers()
+
+    #region Configure
+    ### Parse input ###
+    args = parse_args()
+
+    ### Debug message toggle ###
+    if args.debug:
+        BoardShim.set_log_level(LogLevels.LEVEL_DEBUG.value)
     
-    def BoardInit(args):
-        ### Streaming Params ###
-        refresh_rate_hz = args.refresh_rate
-        window_seconds = args.window_seconds
-        ema_decay = args.ema_decay / args.refresh_rate
-        startup_time = window_seconds
+    ### Reporter Setup ###
+    reporter = setup_reporter(args)
 
-        ### Biosensor board setup ###
-        board = BoardShim(master_board_id, params)
-        board.prepare_session()
-
-        ### Logic Modules ###
-        has_muse_ppg = master_board_id in (BoardIds.MUSE_2_BOARD, BoardIds.MUSE_S_BOARD)
-        
-        fft_size= 64 * 10 # TODO: Make this configurable
-        biometrics_logic = Biometrics(board, has_muse_ppg, fft_size=fft_size, ema_decay=ema_decay)
-
-        logics = [
-            Info(board, window_seconds=window_seconds),
-            PwrBands(board, window_seconds=window_seconds, ema_decay=ema_decay),
-            NeuroFB(board, window_seconds=window_seconds, ema_decay=ema_decay),
-            Addons(board, window_seconds=window_seconds, ema_decay=ema_decay),
-            biometrics_logic
-        ]
-
-        ### Muse 2/S heartbeat support ###
-        if has_muse_ppg:
-            board.config_board('p52')
-            heart_window_seconds = biometrics_logic.window_seconds
-            startup_time = max(startup_time, heart_window_seconds)
-        
-        ### Add ml action to logics if enabled
-        if args.enable_action:
-            logics.append(MLAction(board, ema_decay = ema_decay * args.action_ema_multiplier))
-
-        BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Intializing (wait {}s)'.format(startup_time))
-        board.start_stream(streamer_params=args.streamer_params)
-        time.sleep(startup_time)
-        BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Tracking Started')
-
-        return board, logics, refresh_rate_hz
-
+    #region init
+    max_retries = args.retry_count
     while True:
         try:
             # Initialize board and logics
             board, logics, refresh_rate_hz = BoardInit(args)
             break
         except KeyboardInterrupt:
-            BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Shutting down')
+            BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Received interrupt signal! Shutting down...')
             return
         except BrainFlowError as board_init_error:
-            if board_init_error.exit_code == BrainFlowExitCodes.BOARD_NOT_READY_ERROR:
-                BoardShim.log_message(LogLevels.LEVEL_WARN.value, 'Board not ready, retrying...')
+            if board_init_error.exit_code == BrainFlowExitCodes.BOARD_NOT_READY_ERROR and max_retries > 0:
+                BoardShim.log_message(LogLevels.LEVEL_WARN.value, f'Biosensor board not ready! (Retries left: {max_retries})')
+                max_retries -= 1
+            else:
+                BoardShim.log_message(LogLevels.LEVEL_ERROR.value, f'Biosensor board error: {board_init_error}')
+                return
 
-    while True:
-        try:
+    #region main loop
+    try:
+        while True:
             # get execution start time for time delay
             start_time = time.time()
             
@@ -185,29 +213,21 @@ def main():
             BoardShim.log_message(LogLevels.LEVEL_DEBUG.value, "Sleeping")
             execution_time = time.time() - start_time
             sleep_time = 1.0 / refresh_rate_hz - execution_time
-            sleep_time = sleep_time if sleep_time > 0 else 0
+            sleep_time = max(sleep_time, 0)
             time.sleep(sleep_time)
+            
+    except TimeoutError as e:
+        # display disconnect and release old session
+        reporter.send({Info.__name__ : {Info.CONNECTED:False}})
+        board.release_session()
 
-        except TimeoutError as e:
-            # display disconnect and release old session
-            reporter.send({Info.__name__ : {Info.CONNECTED:False}})
-            board.release_session()
-
-            BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Biosensor board error: ' + str(e))
-
-            # attempt reinitialize 3 times
-            for i in range(args.retry_count):
-                try: 
-                    board, logics, refresh_rate_hz = BoardInit(args)
-                    break
-                except BrainFlowError as e:
-                    BoardShim.log_message(LogLevels.LEVEL_ERROR.value, 'Retry {} Biosensor board error: {}'.format(i, str(e)))
-        except KeyboardInterrupt:
-            BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Shutting down')
-            board.stop_stream()
-        finally:
-            reporter.send({Info.__name__ : {Info.CONNECTED:False}})
-            board.release_session()
+        BoardShim.log_message(LogLevels.LEVEL_INFO.value, f'Biosensor board error: {e}')
+    except KeyboardInterrupt:
+        BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'Received interrupt signal! Shutting down...')
+        board.stop_stream()
+    finally:
+        reporter.send({Info.__name__ : {Info.CONNECTED:False}})
+        board.release_session()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request fixes an UnboundLocalError exception being thrown when the board fails to initialize and adds a retry logic to the initial board initialization (controlled by --retry-count).
As a result, the script will no longer exit if it encounters and error during the first initialization.

I have also tried to clean up some of the code in `main.py` to hopefully make it more readable.