### PR TITLE
DearpyGui_Viewer : Adds a additional Graph to the viewer which shows actions from the model/intent module

### DIFF
--- a/dearpygui_viewer/dearpygui_viewer.py
+++ b/dearpygui_viewer/dearpygui_viewer.py
@@ -125,10 +125,10 @@ def main(args):
             def change_val_in_dict(sender, key, val):
                 plot_show[key] = val
                 print(f"Changed {key} to {val}")
-
+               
             # ToDo initialize data_frames
             with dpg.group(horizontal=False):
-                
+                               
                 def setup_plot_with_limits_and_message_subset(osc_limit_index, osc_plot_limits, osc_subset_labels):
                     tag_plot = f"_bmi_plot_{osc_limit_index}"
                     tag_x_axis = f"_bmi_plot_x_time_{osc_limit_index}"
@@ -153,10 +153,17 @@ def main(args):
                                     def callback(sender, app_data):
                                         change_val_in_dict(sender, current_label, app_data)
                                     return callback
-                                
+
                                 dpg.add_checkbox(label=xlabel, 
                                                 callback=create_callback(xlabel), 
                                                 default_value=True)
+
+                                    
+
+                                if xlabel == 'Action':
+                                    dpg.add_text(" Selected Action is <>",
+                                    label="SelectedActionText", tag="SelectedActionText")
+                                   
 
                     dpg.add_separator()
 
@@ -174,11 +181,16 @@ def main(args):
                             for idx, sub_label in enumerate(key_subset):
                                 assert sub_label in data_digital.keys()
                                 if plot_show[sub_label] :
+
                                     #time relative to t_digital_plor
                                     x_relate = new_data_dict[sub_label][1] - time_viewer_started
                                     y = new_data_dict[sub_label][0]
                                     data_digital[sub_label].append([x_relate,y])
                                     dpg.set_value(sub_label,  [*zip(*data_digital[sub_label])])
+
+                                    if sub_label == 'Action': #todo refactor none check
+                                        value = y
+                                        dpg.set_value("SelectedActionText", "Selected Action is " + str(value))
                                     
                     for plot_subset_idx, (key, value) in enumerate(make_dict_subgraph_to_limit_and_label.items()):
                         (limit, key_subset) = value

--- a/dearpygui_viewer/dearpygui_viewer.py
+++ b/dearpygui_viewer/dearpygui_viewer.py
@@ -202,6 +202,9 @@ def main(args):
                         new_data_dict = fetch_action_data_and_timestep_for_keys(ml_action_buffer)
                         _update_subplots(plot_subset_idx + len(make_dict_subgraph_to_limit_and_label.keys()), key_subset, new_data_dict)
 
+                    time.sleep(0.001) #reduce stress caused by readers
+                    # end of function _update_plot 
+
                 for plot_subset_idx, (key, value) in enumerate(make_dict_subgraph_to_limit_and_label.items()):
                     (limit, key_subset) = value
                     setup_plot_with_limits_and_message_subset(plot_subset_idx, limit, key_subset)

--- a/dearpygui_viewer/dearpygui_viewer.py
+++ b/dearpygui_viewer/dearpygui_viewer.py
@@ -5,6 +5,7 @@ import argparse
 from collections import deque
 
 import osc_server
+from ml_actions_buffer import MLActionsBuffer
 
 PLOT_WIDTH = 800
 DEQUEUE_SIZE = 1024*2
@@ -19,18 +20,23 @@ t_count_plots = 0
 
 # --------------------------------------------
 def main(args):
-    def run_osc_server(osc_ip, osc_port_listen, osc_port_forward):
-        osc_server.run_server(osc_ip, osc_port_listen, osc_port_forward)  
+
+    ml_action_buffer = None
+    if args.actions > 0:
+        ml_action_buffer = MLActionsBuffer(args.actions, osc_server.MAX_STORED_TIMESTEPS)
+
+    def run_osc_server(osc_ip, osc_port_listen, osc_port_forward, ml_action_buffer):
+        osc_server.run_buffer_server(osc_ip, osc_port_listen, osc_port_forward, ml_action_buffer)  
 
     def run_osc_forward(osc_ip, osc_port_listen, osc_port_forward):
         osc_server.forward_messages(osc_ip, osc_port_listen, osc_port_forward)
 
-    def start_servers_once(osc_ip, osc_port_listen, osc_port_forward):
+    def start_servers_once(osc_ip, osc_port_listen, osc_port_forward, ml_action_buffer=None):
         global server_started
         if not server_started:
             thread = threading.Thread(
                 target=run_osc_server,
-                args=(osc_ip, osc_port_listen, osc_port_forward),
+                args=(osc_ip, osc_port_listen, osc_port_forward, ml_action_buffer),
                 daemon=True
             )
             thread.start()
@@ -47,10 +53,10 @@ def main(args):
 
             server_started = True
 
-    start_servers_once(args.ip, args.port_listen, args.port_forward)
+    start_servers_once(args.ip, args.port_listen, args.port_forward, ml_action_buffer)
 
 
-    def fetch_set_label_data_and_timestep_for_keys(osc_keys):
+    def fetch_bmi_data_and_timestep_for_keys(osc_keys):
 
         osc_data_per_key = [ osc_server.read_last_from_osc_buffer(key) for key in osc_keys]
 
@@ -61,43 +67,60 @@ def main(args):
                 data, time = osc_data_per_key[idx_label]
                 next_data[label] = (data, time)
 
+
+        return next_data
+
+    def fetch_action_data_and_timestep_for_keys(ml_action_buffer=None):
+
+        next_data = {}
+
+        if ml_action_buffer is not None:
+            for key in ml_action_buffer._action_paths_to_key.values():
+                data, time = ml_action_buffer.read_from_osc_ml_action_buffer(key)
+                next_data[key] = (data, time)
+
         return next_data
 
     def get_labels_from_osc():
 
-        osc_powerband_avg_labels = [ key for key in osc_server.OSC_PATHS_TO_KEY.values()]
+        osc_powerband_avg_labels = [ key for key in osc_server.BMI_PATHS_TO_KEY.values()]
 
         return osc_powerband_avg_labels
 
+    def make_dict_subgraphkey_to_limit_and_label(osc_labels):
+        # osc_server.OSC_LIMITS[ key] is a tuple
+        graph_id_to_limits = osc_server.GRAPH_ID_TO_LIMITS
+        dict_range_to_labels = { subid : (limit,[]) for subid, limit in graph_id_to_limits.items()}
+        for label in osc_labels:
+            graph_id = osc_server.BMI_KEY_TO_GRAPH_ID[label]
+            dict_range_to_labels[graph_id] = (dict_range_to_labels[graph_id][0], dict_range_to_labels[graph_id][1] + [label])
+        
+        return dict_range_to_labels
+
+    def make_dict_action_subgraph(ml_action_buffer):
+        if ml_action_buffer is None:
+            return {}
+        return { "Actions" : ( ml_action_buffer.get_action_limits(), list(ml_action_buffer._action_paths_to_key.values())) }
+
 
     dpg.create_context()
-    dpg.create_viewport( title="Dynamic BFiVRC Plot")
+    dpg.create_viewport(title="Dynamic BFiVRC Plot")
     dpg.setup_dearpygui()
-
-    def unique_range_to_sublabels(osc_labels):
-        # osc_server.OSC_LIMITS[ key] is a tuple
-        osc_unique_limits = set([ osc_server.OSC_LIMITS[key] for key in osc_labels])
-        dict_unique_range_to_labels = { limit : [] for limit in osc_unique_limits}
-        for key in osc_labels:
-            osc_limits = osc_server.OSC_LIMITS[key]
-            dict_unique_range_to_labels[osc_limits].append(key)
-        
-        return dict_unique_range_to_labels
 
     window_tag = "window_tag"
     with dpg.window(label="Dynamic BFiVRC Plot", autosize=True, tag=window_tag):
         
         with dpg.tree_node(label="Live Plot", tag="Digital Plots", default_open=True):
             
-
             time.sleep(1)
             osc_labels = get_labels_from_osc()
-            osc_data_dict = fetch_set_label_data_and_timestep_for_keys(osc_labels)      
+            action_labels = list(ml_action_buffer._action_paths_to_key.values() if ml_action_buffer is not None else [])
 
-            plot_show = { osc_label : True for osc_label in osc_labels}
-            data_digital = { osc_label : deque(maxlen=DEQUEUE_SIZE) for osc_label in osc_labels}
+            plot_show = { osc_label : True for osc_label in osc_labels + action_labels}
+            data_digital = { osc_label : deque(maxlen=DEQUEUE_SIZE) for osc_label in osc_labels + action_labels}
 
-            unique_range_to_sublabels = unique_range_to_sublabels(osc_labels)
+            make_dict_subgraph_to_limit_and_label = make_dict_subgraphkey_to_limit_and_label(osc_labels)
+            make_dict_action_subgraph_to_limit_and_label = make_dict_action_subgraph(ml_action_buffer)
 
             def change_val_in_dict(sender, key, val):
                 plot_show[key] = val
@@ -141,34 +164,39 @@ def main(args):
                     global t_count_plots
                     t_count_plots += 1
                     t_digital_plot = time.time() - time_viewer_started
-                    osc_new_data_dict = fetch_set_label_data_and_timestep_for_keys(osc_labels) 
 
-                    if len(osc_new_data_dict) <= 0:
-                            return
-
-                    def _update_subplots(index, key_subset: list[str]):
+                    def _update_subplots(index, key_subset: list[str], new_data_dict):
                         tag_x_axis = f"_bmi_plot_x_time_{index}"
-                        
+
                         dpg.set_axis_limits(tag_x_axis, t_digital_plot - 5, t_digital_plot)
 
-                        sub_new_labels = [ label for label in key_subset if label in osc_new_data_dict.keys()]
-
-                        if len(sub_new_labels) > 0:
-                            for idx, sub_label in enumerate(sub_new_labels):
+                        if len(key_subset) > 0:
+                            for idx, sub_label in enumerate(key_subset):
                                 assert sub_label in data_digital.keys()
                                 if plot_show[sub_label] :
                                     #time relative to t_digital_plor
-                                    x_relate = osc_new_data_dict[sub_label][1] - time_viewer_started
-                                    y = osc_new_data_dict[sub_label][0]
+                                    x_relate = new_data_dict[sub_label][1] - time_viewer_started
+                                    y = new_data_dict[sub_label][0]
                                     data_digital[sub_label].append([x_relate,y])
                                     dpg.set_value(sub_label,  [*zip(*data_digital[sub_label])])
                                     
+                    for plot_subset_idx, (key, value) in enumerate(make_dict_subgraph_to_limit_and_label.items()):
+                        (limit, key_subset) = value
+                        new_data_dict = fetch_bmi_data_and_timestep_for_keys(key_subset)
+                        _update_subplots(plot_subset_idx, key_subset, new_data_dict)
 
-                    for plot_subset_idx, (key, value) in enumerate(unique_range_to_sublabels.items()):
-                        _update_subplots(plot_subset_idx, value)
+                    for plot_subset_idx, (key, value) in enumerate(make_dict_action_subgraph_to_limit_and_label.items()):
+                        (limit, key_subset) = value
+                        new_data_dict = fetch_action_data_and_timestep_for_keys(ml_action_buffer)
+                        _update_subplots(plot_subset_idx + len(make_dict_subgraph_to_limit_and_label.keys()), key_subset, new_data_dict)
 
-                for plot_subset_idx, (key, value) in enumerate(unique_range_to_sublabels.items()):
-                    setup_plot_with_limits_and_message_subset(plot_subset_idx, key, value)
+                for plot_subset_idx, (key, value) in enumerate(make_dict_subgraph_to_limit_and_label.items()):
+                    (limit, key_subset) = value
+                    setup_plot_with_limits_and_message_subset(plot_subset_idx, limit, key_subset)
+
+                for plot_subset_idx, (key, value) in enumerate(make_dict_action_subgraph_to_limit_and_label.items()):
+                    (limit, key_subset) = value
+                    setup_plot_with_limits_and_message_subset(plot_subset_idx + len(make_dict_subgraph_to_limit_and_label.keys()), limit, key_subset)
 
                 with dpg.item_handler_registry(tag="handler_tag_ref"):
                     dpg.add_item_visible_handler(callback=_update_plot)
@@ -183,5 +211,6 @@ if __name__ == "__main__":
     parser.add_argument("--ip", type=str, default="127.0.0.1", help="IP address for OSC messages")
     parser.add_argument("--port_listen", type=int, default=9010, help="The port to listen on")
     parser.add_argument("--port_forward", type=int, default=9000, help="The port to forward the data", required=False)
+    parser.add_argument("--actions", type=int, default=0, help="Set number of actions to be viewed (max 16)", required=False)
     args = parser.parse_args()
     main(args)

--- a/dearpygui_viewer/ml_actions_buffer.py
+++ b/dearpygui_viewer/ml_actions_buffer.py
@@ -18,21 +18,23 @@ class MLActionsBuffer:
 
     def generate_action_paths(self, max_actions):
         paths = []
+        paths.append("/avatar/parameters/BFI/MLAction/Action")
         for i in range(max_actions):
-            paths.append("/avatar/parameters/BFI/Action" + str(i))
+            paths.append("/avatar/parameters/BFI/MLAction/Action" + str(i))
         return paths
         
     def _make_buffers(self, num_actions):
 
         paths  = self.generate_action_paths(num_actions)
-        self._action_paths_to_key = { path : "Action" + str(i) for i, path in enumerate(paths)}
+        self._action_paths_to_key = { path : "Action" + str(i - 1) for i, path in enumerate(paths)}
+        self._action_paths_to_key["/avatar/parameters/BFI/MLAction/Action"] = "Action" # todo refactor generation of paths
 
         for key in self._action_paths_to_key.values():
             self.action_buffers[key] = ProtectedOSCBuffer(self.max_stored_timesteps)
             self.action_buffers[key].deque.append((0.0, 0.0))
 
     def get_action_key(self, path):
-        return self._action_paths_to_key[path]
+        return self._action_paths_to_key[path] # current selected action  # todo review
 
     def read_from_osc_ml_action_buffer(self, key):
         self.action_buffers[key].lock.acquire()

--- a/dearpygui_viewer/ml_actions_buffer.py
+++ b/dearpygui_viewer/ml_actions_buffer.py
@@ -1,0 +1,49 @@
+from protected_osc_buffer import ProtectedOSCBuffer
+import time
+
+class MLActionsBuffer:
+
+    def __init__(self, num_actions, max_stored_timesteps):
+        self.action_buffers = {}
+        self._action_paths_to_key = {}
+        self.num_actions = 0
+        self.max_stored_timesteps = max_stored_timesteps
+        if num_actions <= 0:
+            raise ValueError("num_actions must be a non-negative integer.")
+        if num_actions > 16: 
+            num_actions = 16
+            print("viewer does not support more than 16 actions, reducing to 16...")
+        self.num_actions = num_actions
+        self._make_buffers(num_actions)
+
+    def generate_action_paths(self, max_actions):
+        paths = []
+        for i in range(max_actions):
+            paths.append("/avatar/parameters/BFI/Action" + str(i))
+        return paths
+        
+    def _make_buffers(self, num_actions):
+
+        paths  = self.generate_action_paths(num_actions)
+        self._action_paths_to_key = { path : "Action" + str(i) for i, path in enumerate(paths)}
+
+        for key in self._action_paths_to_key.values():
+            self.action_buffers[key] = ProtectedOSCBuffer(self.max_stored_timesteps)
+            self.action_buffers[key].deque.append((0.0, 0.0))
+
+    def get_action_key(self, path):
+        return self._action_paths_to_key[path]
+
+    def read_from_osc_ml_action_buffer(self, key):
+        self.action_buffers[key].lock.acquire()
+        data = list(self.action_buffers[key].deque)[-1]
+        self.action_buffers[key].lock.release()
+        return data
+
+    def write_to_osc_ml_action_buffer(self, key, value):
+        self.action_buffers[key].lock.acquire()
+        self.action_buffers[key].deque.append((value, time.time()))
+        self.action_buffers[key].lock.release()
+
+    def get_action_limits(self):
+        return (0.0, 1.0)

--- a/dearpygui_viewer/osc_device_simulation.py
+++ b/dearpygui_viewer/osc_device_simulation.py
@@ -1,5 +1,6 @@
 from pythonosc import udp_client
-from osc_server import OSC_PATHS_TO_KEY, ELAPSED_TIME_PATH
+from osc_server import BMI_PATHS_TO_KEY
+from ml_actions_buffer import MLActionsBuffer
 import argparse
 
 import time
@@ -8,13 +9,18 @@ SLEEP_TIME = 0.08 #seconds
 
 startTime = time.time()
 
-osc_paths = [ key for key in OSC_PATHS_TO_KEY.keys()]
+osc_paths = [ key for key in BMI_PATHS_TO_KEY.keys()]
 
-def run_client(port):
+def run_client(port, num_ml_actions=0):
     client = udp_client.SimpleUDPClient("127.0.0.1", port)
 
     print(osc_paths)
     assert isinstance(osc_paths[0], str)
+
+    action_paths = []
+    if num_ml_actions > 0:
+        action_paths = MLActionsBuffer(num_ml_actions, 10).generate_action_paths(num_ml_actions)
+        print (action_paths)
 
     def _get_debuggable_times(time = 0.0):
         return 0.75 if (time % 10.0) > 7.5 else 0.5 if (time % 10.0) > 5.0 else 0.25 if (time % 10.0) > 2.5 else 0.0
@@ -24,8 +30,10 @@ def run_client(port):
             for idx, path in enumerate(osc_paths):
                 client.send_message(path, _get_debuggable_times(time.time()))
 
+            for idx, path in enumerate(action_paths):
+                client.send_message(path, _get_debuggable_times(time.time()))
+
             elapsedTime = time.time() - startTime
-            client.send_message(ELAPSED_TIME_PATH, elapsedTime)
             time.sleep(SLEEP_TIME)
     except KeyboardInterrupt:
         print("Shutting down testing client...")
@@ -37,7 +45,8 @@ if __name__ == "__main__":
     ## Parse argument port
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=9010, help="The port to listen on")
+    parser.add_argument("--actions", type=int, default=0, help="Number of actions of the intent model trained", required=False)
     args = parser.parse_args()
 
-    run_client(port=args.port)  
+    run_client(port=args.port, num_ml_actions=args.actions)  
         

--- a/dearpygui_viewer/osc_server.py
+++ b/dearpygui_viewer/osc_server.py
@@ -1,17 +1,15 @@
-import threading
-
 from pythonosc.dispatcher import Dispatcher
 from pythonosc import osc_server, udp_client
+from ml_actions_buffer import MLActionsBuffer
+from protected_osc_buffer import ProtectedOSCBuffer
 from collections import deque
 import queue
 import time
 
-OSC_KEY_BASIS = "/avatar/parameters/BFI"
+OSC_BMI_KEY_BASIS = "/avatar/parameters/BFI"
 MAX_STORED_TIMESTEPS = 200
 
-ELAPSED_TIME_PATH = "/avatar/parameters/BFI/Info/SecondsSinceLastUpdate"
-
-OSC_PATHS_TO_KEY = { 
+BMI_PATHS_TO_KEY = { 
     "/avatar/parameters/BFI/NeuroFB/FocusLeft": "NeuroFB_FocusLeft",
     "/avatar/parameters/BFI/NeuroFB/FocusRight": "NeuroFB_FocusRight",
     "/avatar/parameters/BFI/NeuroFB/FocusAvg": "NeuroFB_FocusAvg",
@@ -39,47 +37,42 @@ OSC_PATHS_TO_KEY = {
     "/avatar/parameters/BFI/Biometrics/OxygenPercent": "OxygenPercent"
 }
 
-
-OSC_LIMITS = {
-    "NeuroFB_FocusLeft": (-1.0, 1.0),
-    "NeuroFB_FocusRight": (-1.0, 1.0),
-    "NeuroFB_FocusAvg": (-1.0, 1.0),
-    "NeuroFB_RelaxLeft": (-1.0, 1.0),
-    "NeuroFB_RelaxRight": (-1.0, 1.0),
-    "NeuroFB_RelaxAvg": (-1.0, 1.0),
-    "PwrBands_Left_Delta": (0.0, 1.0),
-    "PwrBands_Left_Theta": (0.0, 1.0),
-    "PwrBands_Left_Alpha": (0.0, 1.0),
-    "PwrBands_Left_Beta": (0.0, 1.0),
-    "PwrBands_Left_Gamma": (0.0, 1.0),
-    "PwrBands_Right_Delta": (0.0, 1.0),
-    "PwrBands_Right_Theta": (0.0, 1.0),
-    "PwrBands_Right_Alpha": (0.0, 1.0),
-    "PwrBands_Right_Beta": (0.0, 1.0),
-    "PwrBands_Right_Gamma": (0.0, 1.0),
-    "PwrBands_Avg_Delta": (0.0, 1.0),
-    "PwrBands_Avg_Theta": (0.0, 1.0),
-    "PwrBands_Avg_Alpha": (0.0, 1.0),
-    "PwrBands_Avg_Beta": (0.0, 1.0),
-    "PwrBands_Avg_Gamma": (0.0, 1.0),
-    "Biometrics_HeartBeatsPerMinute": (0.0, 255.0),
-    "Biometrics_BreathsPerMinute": (0.0, 255.0),
-    "OxygenPercent": (0.0, 100.0)   
+BMI_KEY_TO_GRAPH_ID = {
+    "NeuroFB_FocusLeft": "NeuroFB",
+    "NeuroFB_FocusRight": "NeuroFB",
+    "NeuroFB_FocusAvg": "NeuroFB",
+    "NeuroFB_RelaxLeft": "NeuroFB",
+    "NeuroFB_RelaxRight": "NeuroFB",
+    "NeuroFB_RelaxAvg":  "NeuroFB",
+    "PwrBands_Left_Delta": "PwrBands",
+    "PwrBands_Left_Theta": "PwrBands",
+    "PwrBands_Left_Alpha": "PwrBands",
+    "PwrBands_Left_Beta": "PwrBands",
+    "PwrBands_Left_Gamma":  "PwrBands",
+    "PwrBands_Right_Delta": "PwrBands",
+    "PwrBands_Right_Theta": "PwrBands",
+    "PwrBands_Right_Alpha": "PwrBands",
+    "PwrBands_Right_Beta": "PwrBands",
+    "PwrBands_Right_Gamma": "PwrBands",
+    "PwrBands_Avg_Delta": "PwrBands",
+    "PwrBands_Avg_Theta": "PwrBands",
+    "PwrBands_Avg_Alpha": "PwrBands",
+    "PwrBands_Avg_Beta": "PwrBands",
+    "PwrBands_Avg_Gamma": "PwrBands",
+    "Biometrics_HeartBeatsPerMinute": "Biometrics",
+    "Biometrics_BreathsPerMinute": "Biometrics",
+    "OxygenPercent": "BiometricsPercent"
 }
 
-class ProtectedOSCBuffer:
-    def __init__(self, max_len = 50):
-        self.lock = threading.Lock()
-        self.deque = deque(maxlen=max_len)
+GRAPH_ID_TO_LIMITS = {
+    "NeuroFB": (-1.0, 1.0),
+    "PwrBands": (0.0, 1.0),
+    "Biometrics": (0.0, 255.0),
+    "BiometricsPercent": (0.0, 100.0)   
+}
 
-osc_buffers = { key : ProtectedOSCBuffer(MAX_STORED_TIMESTEPS) for path, key in OSC_PATHS_TO_KEY.items() }
+osc_buffers = { key : ProtectedOSCBuffer(MAX_STORED_TIMESTEPS) for path, key in BMI_PATHS_TO_KEY.items() }
 forward_queue = queue.Queue()
-
-for osc_buffer in osc_buffers.values():
-    osc_buffer.deque.append((0.0,0.0)) # vuffer shaped (value, time)
-
-osc_elapsed_time_buffer = ProtectedOSCBuffer(MAX_STORED_TIMESTEPS)
-osc_elapsed_time_buffer.deque.append(0.0)
 
 def write_to_osc_buffer(path, value):
     osc_buffers[path].lock.acquire()
@@ -94,8 +87,8 @@ def read_last_from_osc_buffer(path):
     return data
 
 def _osc_message_data_handler(path, value):
-    if path in OSC_PATHS_TO_KEY:
-        write_to_osc_buffer(OSC_PATHS_TO_KEY[path], value)
+    if path in BMI_PATHS_TO_KEY:
+        write_to_osc_buffer(BMI_PATHS_TO_KEY[path], value)
 
 def _osc_message_forward_handler(path, value):
     forward_queue.put( (path, value))
@@ -115,11 +108,23 @@ def forward_messages(osc_ip, osc_port_listen, osc_port_forward):
             print("Shutting down forwarder...")
 
 
-def run_server(osc_ip, osc_port_listen, osc_port_forward = None):
+def run_buffer_server(osc_ip, osc_port_listen, osc_port_forward = None, ml_actions_buffer = None):
     dispatcher = Dispatcher()
     if osc_port_forward is not None:
         dispatcher.map( "/avatar/parameters/BFI/*", _osc_message_forward_handler)
     dispatcher.map("/avatar/parameters/BFI/*", _osc_message_data_handler)
+
+    if ml_actions_buffer is not None:
+
+        def _osc_message_action_handler(path, value):
+            try :
+                key = ml_actions_buffer.get_action_key(path)
+                ml_actions_buffer.write_to_osc_ml_action_buffer(key, value)
+            except KeyError:
+                print("Key not found in action buffer, ignoring...")
+                return
+
+        dispatcher.map("/avatar/parameters/BFI/Action*", _osc_message_action_handler)    
 
     server = osc_server.BlockingOSCUDPServer(
         (osc_ip, osc_port_listen), dispatcher)

--- a/dearpygui_viewer/osc_server.py
+++ b/dearpygui_viewer/osc_server.py
@@ -115,14 +115,16 @@ def run_buffer_server(osc_ip, osc_port_listen, osc_port_forward = None, ml_actio
     dispatcher.map("/avatar/parameters/BFI/*", _osc_message_data_handler)
 
     if ml_actions_buffer is not None:
+        ignored_paths = []
 
         def _osc_message_action_handler(path, value):
             try :
                 key = ml_actions_buffer.get_action_key(path)
                 ml_actions_buffer.write_to_osc_ml_action_buffer(key, value)
             except KeyError:
-                print("Key not found in action buffer, ignoring..." + path + str(value))
-                return
+                if path not in ignored_paths:
+                    ignored_paths.append(key)
+                    print("Key not found in action buffer, ignoring... " + path + "/"+ str(value))
 
         dispatcher.map("/avatar/parameters/BFI/MLAction*", _osc_message_action_handler)    
 

--- a/dearpygui_viewer/osc_server.py
+++ b/dearpygui_viewer/osc_server.py
@@ -121,10 +121,10 @@ def run_buffer_server(osc_ip, osc_port_listen, osc_port_forward = None, ml_actio
                 key = ml_actions_buffer.get_action_key(path)
                 ml_actions_buffer.write_to_osc_ml_action_buffer(key, value)
             except KeyError:
-                print("Key not found in action buffer, ignoring...")
+                print("Key not found in action buffer, ignoring..." + path + str(value))
                 return
 
-        dispatcher.map("/avatar/parameters/BFI/Action*", _osc_message_action_handler)    
+        dispatcher.map("/avatar/parameters/BFI/MLAction*", _osc_message_action_handler)    
 
     server = osc_server.BlockingOSCUDPServer(
         (osc_ip, osc_port_listen), dispatcher)

--- a/dearpygui_viewer/protected_osc_buffer.py
+++ b/dearpygui_viewer/protected_osc_buffer.py
@@ -1,0 +1,8 @@
+import threading
+from collections import deque
+
+class ProtectedOSCBuffer:
+    def __init__(self, max_len = 50):
+        self.lock = threading.Lock()
+        self.deque = deque(maxlen=max_len)
+        self.deque.append((0.0, 0.0))

--- a/dearpygui_viewer/test/test_MLActionBuffer.py
+++ b/dearpygui_viewer/test/test_MLActionBuffer.py
@@ -1,0 +1,75 @@
+import sys
+import os
+
+viewer_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Add viewer directory to sys.path
+sys.path.append(viewer_path)
+
+# Now you can import your module
+import ml_actions_buffer as ml_actions_buffer
+
+import unittest
+
+class TestMLActionBuffer(unittest.TestCase):
+
+    maxStoredTimesteps = 10
+
+    def test_init_with_actions(self):
+        buffer = ml_actions_buffer.MLActionsBuffer(3, self.maxStoredTimesteps)
+        self.assertEqual(buffer.max_stored_timesteps, self.maxStoredTimesteps)
+        self.assertEqual(buffer.num_actions, 3)
+        self.assertEqual(buffer._action_paths_to_key, {"/avatar/parameters/BFI/Action0": "Action0",
+                                                      "/avatar/parameters/BFI/Action1": "Action1",
+                                                      "/avatar/parameters/BFI/Action2": "Action2"})
+        self.assertEqual(len(buffer.action_buffers), 3)
+
+    def test_init_empty_behaviour(self):
+        with self.assertRaises(ValueError):
+            buffer = ml_actions_buffer.MLActionsBuffer(0,  self.maxStoredTimesteps)
+
+    def test_init_negative_num_actions(self):
+        with self.assertRaises(ValueError):
+            ml_actions_buffer.MLActionsBuffer(-1,  self.maxStoredTimesteps)
+    
+    def test_init_non_integer_num_actions(self):
+        with self.assertRaises(TypeError):
+            ml_actions_buffer.MLActionsBuffer(1.5,  self.maxStoredTimesteps)
+
+    def test_init_too_many_actions(self):
+        buffer = ml_actions_buffer.MLActionsBuffer(17,  self.maxStoredTimesteps)
+        self.assertEqual(buffer.num_actions, 16)
+        self.assertEqual(buffer._action_paths_to_key, {"/avatar/parameters/BFI/Action0": "Action0",
+                                                      "/avatar/parameters/BFI/Action1": "Action1",
+                                                      "/avatar/parameters/BFI/Action2": "Action2",
+                                                      "/avatar/parameters/BFI/Action3": "Action3",
+                                                      "/avatar/parameters/BFI/Action4": "Action4",
+                                                      "/avatar/parameters/BFI/Action5": "Action5",
+                                                      "/avatar/parameters/BFI/Action6": "Action6",
+                                                      "/avatar/parameters/BFI/Action7": "Action7",
+                                                      "/avatar/parameters/BFI/Action8": "Action8",
+                                                      "/avatar/parameters/BFI/Action9": "Action9",
+                                                      "/avatar/parameters/BFI/Action10": "Action10",
+                                                      "/avatar/parameters/BFI/Action11": "Action11",
+                                                      "/avatar/parameters/BFI/Action12": "Action12",
+                                                      "/avatar/parameters/BFI/Action13": "Action13",
+                                                      "/avatar/parameters/BFI/Action14": "Action14",
+                                                      "/avatar/parameters/BFI/Action15": "Action15"})
+        self.assertEqual(len(buffer.action_buffers), 16)
+    
+    def test_functioning_read_and_write(self):
+        buffer = ml_actions_buffer.MLActionsBuffer(3,  self.maxStoredTimesteps)
+        print(buffer.action_buffers)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action0")[0], 0.0)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action1")[0], 0.0)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action2")[0], 0.0)
+        buffer.write_to_osc_ml_action_buffer("Action0", 1.0)
+        buffer.write_to_osc_ml_action_buffer("Action1", 2.0)
+        buffer.write_to_osc_ml_action_buffer("Action2", 3.0)
+        buffer.write_to_osc_ml_action_buffer("Action2", 3.0)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action0")[0], 1.0)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action1")[0], 2.0)
+        self.assertEqual(buffer.read_from_osc_ml_action_buffer("Action2")[0], 3.0)
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/dearpygui_viewer/test/test_MLActionBuffer.py
+++ b/dearpygui_viewer/test/test_MLActionBuffer.py
@@ -19,10 +19,12 @@ class TestMLActionBuffer(unittest.TestCase):
         buffer = ml_actions_buffer.MLActionsBuffer(3, self.maxStoredTimesteps)
         self.assertEqual(buffer.max_stored_timesteps, self.maxStoredTimesteps)
         self.assertEqual(buffer.num_actions, 3)
-        self.assertEqual(buffer._action_paths_to_key, {"/avatar/parameters/BFI/Action0": "Action0",
-                                                      "/avatar/parameters/BFI/Action1": "Action1",
-                                                      "/avatar/parameters/BFI/Action2": "Action2"})
-        self.assertEqual(len(buffer.action_buffers), 3)
+        self.assertEqual(buffer._action_paths_to_key, {
+                                                      "/avatar/parameters/BFI/MLAction/Action": "Action",
+                                                      "/avatar/parameters/BFI/MLAction/Action0": "Action0",
+                                                      "/avatar/parameters/BFI/MLAction/Action1": "Action1",
+                                                      "/avatar/parameters/BFI/MLAction/Action2": "Action2"})
+        self.assertEqual(len(buffer.action_buffers), 4)
 
     def test_init_empty_behaviour(self):
         with self.assertRaises(ValueError):
@@ -39,23 +41,24 @@ class TestMLActionBuffer(unittest.TestCase):
     def test_init_too_many_actions(self):
         buffer = ml_actions_buffer.MLActionsBuffer(17,  self.maxStoredTimesteps)
         self.assertEqual(buffer.num_actions, 16)
-        self.assertEqual(buffer._action_paths_to_key, {"/avatar/parameters/BFI/Action0": "Action0",
-                                                      "/avatar/parameters/BFI/Action1": "Action1",
-                                                      "/avatar/parameters/BFI/Action2": "Action2",
-                                                      "/avatar/parameters/BFI/Action3": "Action3",
-                                                      "/avatar/parameters/BFI/Action4": "Action4",
-                                                      "/avatar/parameters/BFI/Action5": "Action5",
-                                                      "/avatar/parameters/BFI/Action6": "Action6",
-                                                      "/avatar/parameters/BFI/Action7": "Action7",
-                                                      "/avatar/parameters/BFI/Action8": "Action8",
-                                                      "/avatar/parameters/BFI/Action9": "Action9",
-                                                      "/avatar/parameters/BFI/Action10": "Action10",
-                                                      "/avatar/parameters/BFI/Action11": "Action11",
-                                                      "/avatar/parameters/BFI/Action12": "Action12",
-                                                      "/avatar/parameters/BFI/Action13": "Action13",
-                                                      "/avatar/parameters/BFI/Action14": "Action14",
-                                                      "/avatar/parameters/BFI/Action15": "Action15"})
-        self.assertEqual(len(buffer.action_buffers), 16)
+        self.assertEqual(buffer._action_paths_to_key, {"/avatar/parameters/BFI/MLAction/Action": "Action",
+                                                      "/avatar/parameters/BFI/MLAction/Action0": "Action0",
+                                                      "/avatar/parameters/BFI/MLAction/Action1": "Action1",
+                                                      "/avatar/parameters/BFI/MLAction/Action2": "Action2",
+                                                      "/avatar/parameters/BFI/MLAction/Action3": "Action3",
+                                                      "/avatar/parameters/BFI/MLAction/Action4": "Action4",
+                                                      "/avatar/parameters/BFI/MLAction/Action5": "Action5",
+                                                      "/avatar/parameters/BFI/MLAction/Action6": "Action6",
+                                                      "/avatar/parameters/BFI/MLAction/Action7": "Action7",
+                                                      "/avatar/parameters/BFI/MLAction/Action8": "Action8",
+                                                      "/avatar/parameters/BFI/MLAction/Action9": "Action9",
+                                                      "/avatar/parameters/BFI/MLAction/Action10": "Action10",
+                                                      "/avatar/parameters/BFI/MLAction/Action11": "Action11",
+                                                      "/avatar/parameters/BFI/MLAction/Action12": "Action12",
+                                                      "/avatar/parameters/BFI/MLAction/Action13": "Action13",
+                                                      "/avatar/parameters/BFI/MLAction/Action14": "Action14",
+                                                      "/avatar/parameters/BFI/MLAction/Action15": "Action15"})
+        self.assertEqual(len(buffer.action_buffers), 17)
     
     def test_functioning_read_and_write(self):
         buffer = ml_actions_buffer.MLActionsBuffer(3,  self.maxStoredTimesteps)


### PR DESCRIPTION
## Description
 - additional parameter --actions allows up to 16 actions osc messages to be viewed live 
 - expects /avatar/parameters/BFI/Action\<ID\> , with id being a leading 0 counter
 - call parameter --actions <num_actions> on dearpygui_viewer.py and main.py with parameter --enable_action
 - Tested with device simulation