### PR TITLE
feat: adjust heart rate frequency for VRChat compatibility

### DIFF
--- a/logic/biometrics.py
+++ b/logic/biometrics.py
@@ -17,6 +17,9 @@ class Biometrics(OptionalBaseLogic):
     def __init__(self, board, supported=True, fft_size=1024, ema_decay=0.025):
         super().__init__(board, supported)
 
+        self.last_hr = None
+        self.hr_threshold = 0.01
+
         if supported:
             board_id = board.get_board_id()
         
@@ -91,7 +94,7 @@ class Biometrics(OptionalBaseLogic):
         # create data dictionary
         ppg_dict = {
             Biometrics.OXYGEN_PERCENT : oxygen_level,
-            Biometrics.HEART_FREQ : heart_bpm / 60,
+            Biometrics.HEART_FREQ : heart_bpm / 60 / 4,
             Biometrics.HEART_BPM : heart_bpm,
             Biometrics.RESP_FREQ : resp_bpm / 60,
             Biometrics.RESP_BPM : resp_bpm
@@ -108,8 +111,14 @@ class Biometrics(OptionalBaseLogic):
         ppg_dict = {k:v for k,v in zip(ppg_dict.keys(), self.current_values.tolist())}
         for k in (Biometrics.HEART_BPM, Biometrics.RESP_BPM):
             ppg_dict[k] = int(ppg_dict[k] + 0.5)
+
+        current_hr = ppg_dict[Biometrics.HEART_FREQ]
+        if self.last_hr is None or abs(current_hr - self.last_hr) > self.hr_threshold:
+            self.last_hr = current_hr
+            ret_dict[Biometrics.HEART_FREQ] = current_hr
         
-        ret_dict.update(ppg_dict)
+        stable_params = {k: v for k, v in ppg_dict.items() if k != Biometrics.HEART_FREQ}
+        ret_dict.update(stable_params)
 
         return ret_dict
 

--- a/logic/biometrics.py
+++ b/logic/biometrics.py
@@ -43,7 +43,7 @@ class Biometrics(OptionalBaseLogic):
             highcut = 180 / 60.0
             order = 3
             self.notch_params = iirnotch(0.05, 0.005, self.ppg_sampling_rate) # baseline wander filter
-            self.bp_params = butter(order, (2 * lowcut, 2 * highcut), 'bandpass', fs=self.ppg_sampling_rate) # multiplied by 2 due to double peaks
+            self.bp_params = butter(order, (lowcut, highcut), 'bandpass', fs=self.ppg_sampling_rate)
 
     def estimate_heart_rate(self, hr_ir, hr_red):
         # do not modify data
@@ -51,8 +51,7 @@ class Biometrics(OptionalBaseLogic):
 
         def hr_preprocess(hr_arr):
             filted = filtfilt(*self.notch_params, x=hr_arr)
-            filted = filted - np.mean(filted)
-            filted = filted ** 2 # doubles peak count
+            filted -= np.mean(filted)
             filted = filtfilt(*self.bp_params, x=filted)
             return filted
         
@@ -66,20 +65,18 @@ class Biometrics(OptionalBaseLogic):
         ir_peaks, _ = find_peaks(hr_ir, height=0)
 
         # discard anomalous peaks
-        def clean_peaks(peaks, data):
-            peak_vals = data[peaks]
-            med = np.median(peak_vals)
-            diffs = np.abs(peak_vals - med)
-            mad = np.median(diffs)
-            good_idx = np.argwhere(diffs < 3.0 * mad)
-            return peaks[good_idx]
+        def clean_peaks(peaks):
+            diffs = np.diff(peaks)
+            mean_diff = np.mean(diffs)
+            good_diff_idx = np.argwhere(np.abs(diffs - mean_diff) / mean_diff < .30)
+            good_diff_idx += 1
+            return peaks[good_diff_idx]
         
-        red_peaks = clean_peaks(red_peaks, hr_red)
-        ir_peaks = clean_peaks(ir_peaks, hr_ir)
+        red_peaks = clean_peaks(red_peaks)
+        ir_peaks = clean_peaks(ir_peaks)
         
         peak_count = (len(red_peaks) + len(ir_peaks)) * 0.5 # analyzing same time period twice
-        heart_bpm = 60.0 * peak_count / (2.0 * self.window_seconds) # divide by 2 due to double peaks
-
+        heart_bpm = 60.0 * peak_count / (self.window_seconds)
         return heart_bpm
     
     def calculate_data_dict(self):

--- a/logic/biometrics.py
+++ b/logic/biometrics.py
@@ -14,11 +14,14 @@ class Biometrics(OptionalBaseLogic):
     RESP_FREQ = "BreathsPerSecond"
     RESP_BPM = "BreathsPerMinute"
 
+    VRCHAT_HEART_FREQ_DIVISOR = 4
+    HEART_FREQ_UPDATE_THRESHOLD = 0.01
+
     def __init__(self, board, supported=True, fft_size=1024, ema_decay=0.025):
         super().__init__(board, supported)
 
         self.last_hr = None
-        self.hr_threshold = 0.01
+        self.hr_threshold = Biometrics.HEART_FREQ_UPDATE_THRESHOLD
 
         if supported:
             board_id = board.get_board_id()
@@ -94,7 +97,7 @@ class Biometrics(OptionalBaseLogic):
         # create data dictionary
         ppg_dict = {
             Biometrics.OXYGEN_PERCENT : oxygen_level,
-            Biometrics.HEART_FREQ : heart_bpm / 60 / 4,
+            Biometrics.HEART_FREQ : heart_bpm / 60 / Biometrics.VRCHAT_HEART_FREQ_DIVISOR,
             Biometrics.HEART_BPM : heart_bpm,
             Biometrics.RESP_FREQ : resp_bpm / 60,
             Biometrics.RESP_BPM : resp_bpm
@@ -112,13 +115,12 @@ class Biometrics(OptionalBaseLogic):
         for k in (Biometrics.HEART_BPM, Biometrics.RESP_BPM):
             ppg_dict[k] = int(ppg_dict[k] + 0.5)
 
-        current_hr = ppg_dict[Biometrics.HEART_FREQ]
+        current_hr = ppg_dict.pop(Biometrics.HEART_FREQ)
         if self.last_hr is None or abs(current_hr - self.last_hr) > self.hr_threshold:
             self.last_hr = current_hr
             ret_dict[Biometrics.HEART_FREQ] = current_hr
         
-        stable_params = {k: v for k, v in ppg_dict.items() if k != Biometrics.HEART_FREQ}
-        ret_dict.update(stable_params)
+        ret_dict.update(ppg_dict)
 
         return ret_dict
 

--- a/logic/biometrics.py
+++ b/logic/biometrics.py
@@ -1,8 +1,8 @@
 from logic.base_logic import OptionalBaseLogic
 
 from brainflow.board_shim import BoardShim, BrainFlowPresets
-from brainflow.data_filter import DataFilter, AggOperations, NoiseTypes, FilterTypes, DetrendOperations, WindowOperations
-from scipy.signal import find_peaks
+from brainflow.data_filter import DataFilter
+from scipy.signal import find_peaks, iirnotch, butter, filtfilt
 
 import numpy as np
 import utils
@@ -17,7 +17,7 @@ class Biometrics(OptionalBaseLogic):
     VRCHAT_HEART_FREQ_DIVISOR = 4
     HEART_FREQ_UPDATE_THRESHOLD = 0.01
 
-    def __init__(self, board, supported=True, fft_size=1024, ema_decay=0.025):
+    def __init__(self, board, supported=True, window_size=5, ema_decay=0.025):
         super().__init__(board, supported)
 
         self.last_hr = None
@@ -31,45 +31,54 @@ class Biometrics(OptionalBaseLogic):
             self.ppg_sampling_rate = BoardShim.get_sampling_rate(
                 board_id, BrainFlowPresets.ANCILLARY_PRESET)
 
-            self.window_seconds = int(fft_size / self.ppg_sampling_rate) + 1
+            self.window_seconds = window_size
             self.max_sample_size = self.ppg_sampling_rate * self.window_seconds
-            self.fft_size = fft_size
 
             # ema smoothing variables
             self.current_values = None
             self.ema_decay = ema_decay
 
-    def estimate_heart_rate(self, hr_ir, hr_red, ppg_ambient):
+            # hr filters
+            lowcut =  40.0 / 60.0 
+            highcut = 180 / 60.0
+            order = 3
+            self.notch_params = iirnotch(0.05, 0.005, self.ppg_sampling_rate) # baseline wander filter
+            self.bp_params = butter(order, (2 * lowcut, 2 * highcut), 'bandpass', fs=self.ppg_sampling_rate) # multiplied by 2 due to double peaks
+
+    def estimate_heart_rate(self, hr_ir, hr_red):
         # do not modify data
-        hr_ir, hr_red, hr_ambient = np.copy(hr_ir), np.copy(hr_red), np.copy(ppg_ambient)
+        hr_ir, hr_red = np.copy(hr_ir), np.copy(hr_red)
 
-        # Possible min and max heart rate in hz
-        lowcut = 0.5
-        highcut = 4.25
-        order = 4
-
-        # remove ambient light
-        hr_ir = np.clip(hr_ir - hr_ambient, 0, None)
-        hr_red = np.clip(hr_red - hr_ambient, 0, None)
-
-        # detrend and filter down to possible heart rates
-        DataFilter.detrend(hr_red, DetrendOperations.LINEAR)
-        DataFilter.detrend(hr_ir, DetrendOperations.LINEAR)
-        DataFilter.perform_bandpass(hr_red, self.ppg_sampling_rate, lowcut, highcut, order, FilterTypes.BUTTERWORTH, 0)
-        DataFilter.perform_bandpass(hr_ir, self.ppg_sampling_rate, lowcut, highcut, order, FilterTypes.BUTTERWORTH, 0)
+        def hr_preprocess(hr_arr):
+            filted = filtfilt(*self.notch_params, x=hr_arr)
+            filted = filted - np.mean(filted)
+            filted = filted ** 2 # doubles peak count
+            filted = filtfilt(*self.bp_params, x=filted)
+            return filted
         
-        # find peaks in signal
-        red_peaks, _ = find_peaks(hr_red, distance=self.ppg_sampling_rate/2)
-        ir_peaks, _ = find_peaks(hr_ir, distance=self.ppg_sampling_rate/2)
+        hr_red = hr_preprocess(hr_red)
+        hr_ir = hr_preprocess(hr_ir)
 
-        # get inter-peak intervals
-        red_ipis = np.diff(red_peaks) / self.ppg_sampling_rate
-        ir_ipis = np.diff(ir_peaks) / self.ppg_sampling_rate
-        ipis = np.concatenate((red_ipis, ir_ipis))
+        ## peak count approach
+
+        # find peaks
+        red_peaks, _ = find_peaks(hr_red, height=0)
+        ir_peaks, _ = find_peaks(hr_ir, height=0)
+
+        # discard anomalous peaks
+        def clean_peaks(peaks, data):
+            peak_vals = data[peaks]
+            med = np.median(peak_vals)
+            diffs = np.abs(peak_vals - med)
+            mad = np.median(diffs)
+            good_idx = np.argwhere(diffs < 3.0 * mad)
+            return peaks[good_idx]
         
-        # get bpm from mean inter-peak interval
-        average_ipi = np.mean(ipis)
-        heart_bpm = 60 / average_ipi
+        red_peaks = clean_peaks(red_peaks, hr_red)
+        ir_peaks = clean_peaks(ir_peaks, hr_ir)
+        
+        peak_count = (len(red_peaks) + len(ir_peaks)) * 0.5 # analyzing same time period twice
+        heart_bpm = 60.0 * peak_count / (2.0 * self.window_seconds) # divide by 2 due to double peaks
 
         return heart_bpm
     
@@ -80,8 +89,7 @@ class Biometrics(OptionalBaseLogic):
         ppg_data = self.board.get_current_board_data(
             self.max_sample_size, BrainFlowPresets.ANCILLARY_PRESET)
         
-        # get ambient, ir, red channels, and clean the channels with ambient
-        ppg_ambient = ppg_data[self.ppg_channels[2]]
+        # get ir, red channels
         ppg_ir = ppg_data[self.ppg_channels[1]]
         ppg_red = ppg_data[self.ppg_channels[0]]
 
@@ -89,7 +97,7 @@ class Biometrics(OptionalBaseLogic):
         oxygen_level = DataFilter.get_oxygen_level(ppg_ir, ppg_red, self.ppg_sampling_rate) * 0.01
 
         # calculate heartrate
-        heart_bpm = self.estimate_heart_rate(ppg_ir, ppg_red, ppg_ambient)
+        heart_bpm = self.estimate_heart_rate(ppg_ir, ppg_red)
 
         # calculate respiration
         resp_bpm = heart_bpm / 4

--- a/main.py
+++ b/main.py
@@ -130,8 +130,7 @@ def BoardInit(args: argparse.Namespace) -> tuple[BoardShim, list[BaseLogic], int
     ### Logic Modules ###
     has_muse_ppg = master_board_id in (BoardIds.MUSE_2_BOARD, BoardIds.MUSE_S_BOARD)
     
-    fft_size= 64 * 10 # TODO: Make this configurable
-    biometrics_logic = Biometrics(board, has_muse_ppg, fft_size=fft_size, ema_decay=ema_decay)
+    biometrics_logic = Biometrics(board, has_muse_ppg, ema_decay=ema_decay)
 
     logics = [
         Info(board, window_seconds=window_seconds),

--- a/main.py
+++ b/main.py
@@ -59,6 +59,8 @@ def parse_args() -> argparse.Namespace:
                         help='refresh rate for the main loop to run at', required=False, default=60)
     parser.add_argument('--ema-decay', type=float,
                         help='exponential moving average constant to smooth outputs', required=False, default=1)
+    parser.add_argument('--hr-ema-decay', type=float,
+                        help='exponential moving average constant to smooth outputs', required=False, default=0.1)
     parser.add_argument('--retry-count', type=int,
                         help='sets the amount of times to reconnect before giving up', required=False, default=3)
 
@@ -117,6 +119,7 @@ def BoardInit(args: argparse.Namespace) -> tuple[BoardShim, list[BaseLogic], int
     refresh_rate_hz = args.refresh_rate
     window_seconds = args.window_seconds
     ema_decay = args.ema_decay / args.refresh_rate
+    hr_ema_decay = args.hr_ema_decay / args.refresh_rate
     startup_time = window_seconds
 
     ### Parse params ###
@@ -130,7 +133,7 @@ def BoardInit(args: argparse.Namespace) -> tuple[BoardShim, list[BaseLogic], int
     ### Logic Modules ###
     has_muse_ppg = master_board_id in (BoardIds.MUSE_2_BOARD, BoardIds.MUSE_S_BOARD)
     
-    biometrics_logic = Biometrics(board, has_muse_ppg, ema_decay=ema_decay)
+    biometrics_logic = Biometrics(board, has_muse_ppg, ema_decay=hr_ema_decay)
 
     logics = [
         Info(board, window_seconds=window_seconds),


### PR DESCRIPTION
## Purpose
Modify the heart rate frequency calculation by dividing it by 4 to align with VRChat requirements. Additionally, implement a mechanism to update the frequency only when significant changes occur to stabilize the output.

## Background
VRChat has specific requirements for heart rate data frequency.

## Changes
- Modified \logic/biometrics.py\ to divide heart rate frequency by 4.
- Added threshold logic to stabilize updates.
- Refactored magic numbers to constants and simplified dictionary handling.

**Note**: This change adapts the frequency specifically for VRChat. Consequently, the output value does not represent the mathematically correct heart rate frequency, which should be noted as a potential concern.